### PR TITLE
Fixed slow emulator on windows

### DIFF
--- a/hardware/ScreenAdapter.cpp
+++ b/hardware/ScreenAdapter.cpp
@@ -2,8 +2,11 @@
 // Created by maxime on 12/08/23.
 //
 
+#include <thread>
 #include "ScreenAdapter.h"
 #include "Screen.h"
+
+
 
 Screen *win;
 
@@ -21,7 +24,11 @@ ScreenAdapter::ScreenAdapter(Bus *bus) {
 
 [[noreturn]] void ScreenAdapter::run() {
     while (true) {
-        usleep(16667);
+        #ifdef _WIN32
+            Sleep(16);
+        #else
+            usleep(16667);
+        #endif
         image->fill(QColor::fromRgb(0));
         for (int y = 0; y < 224; y++) {
             for (int x = 0; x < 32; x++) {

--- a/hardware/ScreenAdapter.h
+++ b/hardware/ScreenAdapter.h
@@ -8,6 +8,10 @@
 #include <QThread>
 #include "Bus.h"
 
+#ifdef _WIN32
+    #include "windows.h"
+#endif
+
 class ScreenAdapter : public QThread {
     Q_OBJECT
 public:


### PR DESCRIPTION
- Fixed this by using the windows.h header using the Sleep function instead of usleep of QThread This is less precised but is currently the only solution that is working.